### PR TITLE
Fixes to pointer arithmetic

### DIFF
--- a/binop.h
+++ b/binop.h
@@ -438,7 +438,7 @@
     case TRI(TC_PTR, TC_INT, T_MINUS):
     case TRI(TC_PTR, TC_INT, T_MINUSEQ):
         if (!isint(ptrof(o0)->p_key))
-            goto mismatch;
+            goto bad_ptr_arith;
         {
             ici_obj_t   *i;
 
@@ -453,13 +453,11 @@
         
     case TRI(TC_INT, TC_PTR, T_PLUS):
     case TRI(TC_INT, TC_PTR, T_PLUSEQ):
-        if (!isint(ptrof(o1)->p_key))
-            goto mismatch;
         SWAP();
     case TRI(TC_PTR, TC_INT, T_PLUS):
     case TRI(TC_PTR, TC_INT, T_PLUSEQ):
         if (!isint(ptrof(o0)->p_key))
-            goto mismatch;
+            goto bad_ptr_arith;
         {
             ici_obj_t   *i;
 
@@ -633,7 +631,7 @@
     case TRI(TC_PTR, TC_PTR, T_MINUS):
     case TRI(TC_PTR, TC_PTR, T_MINUSEQ):
         if (!isint(ptrof(o1)->p_key) || !isint(ptrof(o0)->p_key))
-            goto mismatch;
+            goto bad_ptr_arith;
         if ((o = objof(ici_int_new(intof(ptrof(o0)->p_key)->i_value
               - intof(ptrof(o1)->p_key)->i_value))) == NULL)
               goto fail;
@@ -671,28 +669,28 @@
 
     case TRI(TC_PTR, TC_PTR, T_LESS):
         if (!isint(ptrof(o1)->p_key) || !isint(ptrof(o0)->p_key))
-            goto mismatch;
+            goto bad_ptr_arith;
         if (intof(ptrof(o0)->p_key)->i_value < intof(ptrof(o1)->p_key)->i_value)
             goto use1;
         goto use0;
 
     case TRI(TC_PTR, TC_PTR, T_GRTEQ):
         if (!isint(ptrof(o1)->p_key) || !isint(ptrof(o0)->p_key))
-            goto mismatch;
+            goto bad_ptr_arith;
         if (intof(ptrof(o0)->p_key)->i_value >=intof(ptrof(o1)->p_key)->i_value)
             goto use1;
         goto use0;
 
     case TRI(TC_PTR, TC_PTR, T_LESSEQ):
         if (!isint(ptrof(o1)->p_key) || !isint(ptrof(o0)->p_key))
-            goto mismatch;
+            goto bad_ptr_arith;
         if (intof(ptrof(o0)->p_key)->i_value <=intof(ptrof(o1)->p_key)->i_value)
             goto use1;
         goto use0;
 
     case TRI(TC_PTR, TC_PTR, T_GRT):
         if (!isint(ptrof(o1)->p_key) || !isint(ptrof(o0)->p_key))
-            goto mismatch;
+            goto bad_ptr_arith;
         if (intof(ptrof(o0)->p_key)->i_value > intof(ptrof(o1)->p_key)->i_value)
             goto use1;
         goto use0;
@@ -712,7 +710,6 @@
             goto use0;
         }
         /* Fall through. */
-    mismatch:
         {
             char        n1[30];
             char        n2[30];
@@ -723,6 +720,10 @@
                 ici_objname(n2, o1));
         }
         ici_error = buf;
+        goto fail;
+
+    bad_ptr_arith:
+        ici_error = "attempt to perform pointer arithmetic with non-indexable ptr(s)";
         goto fail;
     }
 

--- a/ptr.c
+++ b/ptr.c
@@ -7,6 +7,7 @@
 #include "buf.h"
 #include "primes.h"
 #include "cfunc.h"
+#include "str.h"
 
 /*
  * Mark this and referenced unmarked objects, return memory costs.
@@ -58,6 +59,10 @@ hash_ptr(ici_obj_t *o)
 static ici_obj_t *
 fetch_ptr(ici_obj_t *o, ici_obj_t *k)
 {
+    if (k == SSO(aggr))
+        return ptrof(o)->p_aggr;
+    if (k == SSO(key))
+        return ptrof(o)->p_key;
     if (k == objof(ici_zero))
         return ici_fetch(ptrof(o)->p_aggr, ptrof(o)->p_key);
     if (!isint(k) || !isint(ptrof(o)->p_key))

--- a/sstring.h
+++ b/sstring.h
@@ -78,6 +78,8 @@ SSTRING(result, "result")
 SSTRING(critsect, "critsect")
 SSTRING(raw, "raw")
 SSTRING(path, "path")
+SSTRING(aggr, "aggr")
+SSTRING(key, "key")
 #ifndef NOSIGNALS
 SSTRING(ignore, "ignore")
 #endif

--- a/test/tst-misc.ici
+++ b/test/tst-misc.ici
@@ -144,6 +144,12 @@ Actually, we don't check for comparing pointers to different objects yet.
 if (error == NULL)
     fail("failed to fail on bad ptr arithmetic");
 */
+r := &q.aggr; // r is a pointer to the "aggr" pseudo-field of q, i.e., "ZXCVBNM"
+if (*r != "ZXCVBNM")
+    fail("failed to retrieve aggr of ptr");
+r := &q.key; // r is a pointer to the "key" pseudo-field of q, i.e., 2
+if (*r != 2)
+    fail("failed to retrieve key of ptr");
 
 error = NULL; try *1 = 2; onerror;
 if (error == NULL)

--- a/test/tst-misc.ici
+++ b/test/tst-misc.ici
@@ -97,6 +97,54 @@ error = NULL; try p@(1)(); onerror;
 if (error == NULL)
     fail("failed to fail on bad ptr call");
 
+foo := &[array 0,1,2][0];
+bar = &foo[2];
+bar[1] = 7;
+if (foo[3] != 7)
+    fail("failed to assign/index pointer");
+
+p := &"ABCDEFG"[0];
+q := &p[2]; // q.aggr is "ABCDEFG"; q.key is 2; q points to 'C'
+if (*q != "C")
+    fail("failed to deref pointer");
+if (p + 2 != q || 2 + p != q)
+    fail("failed pointer plus int");
+if (q - 2 != p)
+    fail("failed pointer minus int");
+if (q - p != 2)
+    fail("failed pointer minus pointer");
+
+// Aggregate of r should be the array pointed to by p, not the pointer q.
+r := &q[2]; // r.aggr is "ABCDEFG"; r.key is 4; r points to 'E'
+if (*r != "E")
+    fail("failed to deref pointer");
+if (p + 4 != r || 4 + p != r)
+    fail("failed pointer plus int");
+if (r - 4 != p)
+    fail("failed pointer minus int");
+if (r - p != 4)
+    fail("failed pointer minus pointer");
+
+p := &struct()["fish"];
+// Can't index a pointer with a non-numeric key
+error = NULL; try x = p + 1; onerror;
+if (error == NULL)
+    fail("failed to fail on bad ptr arithmetic");
+
+// Can compare pointers to the same actual object, however created...
+p := &("ABC"+"DEFG")[2];
+q := &("ABCD"+"EFG")[2];
+if (p != q)
+    fail("failed pointer plus int");
+// ...but cannot compare pointers to different objects.
+q := &"ZXCVBNM"[2];
+error = NULL; try diff := q - p; onerror;
+/*
+Actually, we don't check for comparing pointers to different objects yet.
+if (error == NULL)
+    fail("failed to fail on bad ptr arithmetic");
+*/
+
 error = NULL; try *1 = 2; onerror;
 if (error == NULL)
     fail("failed to fail on bad ptr assigns");


### PR DESCRIPTION
 Fixed a non-obvious difference between ici and C pointers that could cause subtle bugs.
Also enabled retrieving the aggregate and key from a pointer p using p.aggr and p.key respectively.
