### PR TITLE
Fixed inefficient design of arrays used as deques.

### DIFF
--- a/array.h
+++ b/array.h
@@ -13,63 +13,94 @@
  * The following portion of this file exports to ici.h. --ici.h-start--
  */
 /*
- * The ICI array object. Array objects are implemented in a manner to
- * make them efficient to use as stacks. And they are used that way in the
- * execution engine. A single contiguous array of object pointers is
- * associated with the array. a_base points to its start, a_limit one
- * past its end and a_bot and a_top somewhere in the middle.
+ * The ICI array object.  From an ici program's point of view, an array is an
+ * ordered sequence of objects, indexed by consecutive integers starting at 0.
+ * The function nels() returns the number of entries currently in the
+ * sequence.  Assigning to an index beyond the current end of the sequence
+ * will grow the array to hold that index, and NULL-fill the gap.  The
+ * functions push() and pop() provide efficient insertion and deletion at the
+ * end of the sequence, allowing an array to be used as a stack.  The
+ * functions rpush() and rpop() provide efficient insertion and deletion at
+ * the beginning of the sequence, causing all existing elements to shift by
+ * one place; this allows an array to be used as a double ended queue
+ * ("deque").
  *
- * In the general case, arrays are growable circular buffers (queues). Thus
- * allowing efficient addition and removal from both ends. However, their
- * use in the internals of the execution engine is only as stacks. For
- * efficiency, we desire to be able to ensure that there is some amount of
- * contiguous space available on a stack by just making a single efficient
- * check.
+ * Array objects are implemented as growable circular buffers.  A single
+ * contiguous allocation of object pointers is associated with the array.  A
+ * pair of pointers, a_base and a_limit, point to the start of the allocation,
+ * and one past its end, respectively.  The size of the allocation is thus
+ * (a_limit - a_base).  A second pair of pointers, a_bot and a_top, point to
+ * the start of the sequence, and one past its end, respectively.  An array is
+ * empty when a_top == a_bot.
  *
- * This is easy if they really are stacks, and the bottom is always anchored
- * to the start of allocation. (See Case 1 below.) This condition will
- * be true if *no* rpop() or rpush() operations have been done on the array.
- * Thus we conceptually consider arrays to have two forms. Ones that are
- * stacks (never had rpop() or rpush() done) and ones that are queues
- * (may, possibly, have had rpop() or rpush() done).
+ * When dealing with array objects in C, we recognise two kinds of array: a
+ * "stack" and a "queue".  (The difference is only visible from C, not from
+ * ici.)  A "stack" is defined as any array in which a_bot == a_base:
+ *       ooooooooooooooooooooo.....................
+ *       ^a_base              ^a_top               ^a_limit
+ *       ^a_bot
+ * The size (nels) of a stack is (a_top - a_bot).  The stack is at capacity
+ * when a_top == a_limit.  Pushing and popping elements (up to capacity) is a
+ * simple matter of moving a_top, so is efficient.  Any array which has never
+ * been rpop()ed or rpush()ed is guaranteed to be a stack.
  *
- * Now, if an array is still a stack, you can use the functions (macros):
+ * A "queue" is defined as any array in which a_bot != a_base (ie, any array
+ * that is not a stack).  This happens the first time rpop() or rpush() are
+ * used on a stack, as these functions move a_bot.  If we rpop() a stack,
+ * a_bot advances, and we get a queue of this form:
+ *       ..............ooooooooooooooo.............
+ *       ^a_base       ^a_bot         ^a_top       ^a_limit
+ * If we rpush() a stack, a_bot wraps to a_limit, then moves backwards, and we
+ * get a queue of this form, where a_top < a_bot, and the sequence has split
+ * into two disjoint parts:
+ *       oooooooooooooo.................ooooooooooo
+ *       ^a_base       ^a_top           ^a_bot     ^a_limit
+ * If we repeatedly push() a queue of the first form, so a_top reaches
+ * a_limit, a_top wraps to a_base, forming a queue of the second form.  Note
+ * that in a queue, unlike a stack, a_top must be strictly less than a_limit.
  *
- *     ici_stk_push_chk(a, n)
- *     ici_stk_pop_chk(a, n)
+ * As we push() or rpush() more objects onto a wrapped queue, a_top and a_bot
+ * get closer to each other.  However, we cannot fill the last entry in the
+ * allocation, because then a_top == a_bot, which signals an empty array.  So,
+ * a queue (unlike a stack) must always have one empty entry, and is at
+ * capacity when a_top == (a_bot - 1):
+ *       oooooooooooooooooooooooooooooo.ooooooooooo
+ *       ^a_base                        ^a_bot     ^a_limit
+ *                                     ^a_top
+ * The size (nels) of a queue is (a_top - a_bot) unless a_top < a_bot; in
+ * that case the size of the two disjoint parts are calculated and added.
  *
- * to ensure that there are n spaces or objects available, then just
- * increment/decrement a_top as you push and pop things on the stack.
- * Basically you can assume that object pointers and empty slots are
- * contiguous around a_top.
+ * For both queues and stacks, assigning to an array index that exceeds the
+ * current capacity, or push()ing/rpush()ing an array that is at capacity (as
+ * defined above), will cause the array to grow before the operation can
+ * happen.  The allocation is increased by 50%, with a minimum allocation of 8
+ * elements.  The existing array sequence is placed at the beginning of the
+ * new allocation; so the resulting array is always a stack (a_bot == a_base)
+ * even if it was a queue before.
  *
- * But, if you can not guarantee (by context) that the array is a stack,
- * you can only push, pop, rpush or rpop single object pointers at a time.
- * Basically, the end you are dealing with may be near the wrap point of
- * the circular buffer.
+ * The ici execution engine itself makes extensive use of stacks, but never
+ * turns them into queues.  For this reason, there are some macros and
+ * functions in the ici C API which can only be used on array that is known to
+ * be a stack, and which are more efficient than the functions that deal with
+ * the general case.  These are:
  *
- * Case 1: Pure stack. Only ever been push()ed and pop()ed.
- *   ooooooooooooooooooooo.....................
- *   ^a_base              ^a_top               ^a_limit
- *   ^a_bot
+ *     ici_stk_push_chk(a, n) - check there is room to push at least n elements
+ *     ici_stk_probe(a, i) - ensure the stack has i as a valid index
  *
- * Case 2: Queue. rpush() and/or rpop()s have been done.
- *   ..........ooooooooooooooooooo.............
- *   ^a_base   ^a_bot             ^a_top       ^a_limit
+ * But, if you can not guarantee (by context) that the array is a stack, you
+ * can only push, pop, rpush or rpop single object pointers at a time.
+ * Basically, the end you are dealing with may be near the wrap point of the
+ * circular buffer.
  *
- * Case 3: Queue that has wrapped.
- *   oooooooooooooo.................ooooooooooo
- *   ^a_base       ^a_top           ^a_bot     ^a_limit
+ * A data structure such as this should really use an integer count to
+ * indicate how many used elements there are.  By using pure pointers we have
+ * to keep one empty slot so we don't find ourselves unable to distinguish
+ * full from empty (a_top == a_bot).  But by using simple pointers, only a_top
+ * needs to change as we push and pop elements.  If a_top == a_bot, the array
+ * is empty.
  *
- * A data structure such as this should really use an integer count
- * to indicate how many used elements there are. By using pure pointers
- * we have to keep one empty slot so we don't find ourselves unable
- * to distinguish full from empty (a_top == a_bot). But by using simple
- * pointers, only a_top needs to change as we push and pop elements.
- * If a_top == a_bot, the array is empty.
- *
- * Note that one must never take the atomic form of a stack, and
- * assume the result is still a stack.
+ * Note that one must never take the atomic form of a stack, and assume the
+ * result is still a stack.
  */
 struct ici_array
 {


### PR DESCRIPTION
Old behaviour: For some reason, rpush()ing an empty array (or any array with a_bot==a_base) uses ici_array_grow() to create a space at index 0 for the new entry, even though the array has plenty of empty slots.  In fact, when ici_array_grow() grows an array it ALWAYS leaves one empty slot at the start, apparently so that rpush() could push an element with no further checks.  Pop()ping the rpush()ed element returns it to the same empty state, so alternately calling rpush() and pop() would quickly grow the (empty) array until memory exhaustion.  The design is definitely "unusual"...
New behaviour: rpush()ing an empty array simply wraps a_bot around to a_limit and puts the new entry at the TOP of allocated memory.  The array is only grown if it really is full, and ici_array_grow() no longer leaves the empty slot at the start, it now always converts the array back to a stack (a_bot == a_base) on each reallocation.  There are probably still some inefficiencies in some other array manipulation functions, but it is MUCH better.